### PR TITLE
ci: add github action for running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,56 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1.0.3
+      with:
+        toolchain: 1.31.0
+        profile: minimal
+    - name: Install libftdi1
+      run: sudo apt-get install libftdi1
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+
+  msrv-bindgen:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1.0.3
+      with:
+        toolchain: 1.34.0
+        profile: minimal
+    - name: Install libftdi1-dev
+      run: sudo apt-get install libftdi1-dev
+    - name: Build
+      run: cargo build --verbose --features=bindgen
+    - name: Run tests
+      run: cargo test --verbose --features=bindgen
+
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1.0.3
+      with:
+        toolchain: nightly
+        profile: minimal
+    - name: Install libftdi1-dev
+      run: sudo apt-get install libftdi1-dev
+    - name: Build and run tests (pregenerated)
+      run: cargo test --verbose
+    - name: Build and run tests (bindgen)
+      run: cargo test --verbose --features=bindgen

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
       with:
         toolchain: 1.31.0
         profile: minimal
-    - name: Install libftdi1
-      run: sudo apt-get install libftdi1
+    - name: Install libftdi1-dev
+      run: sudo apt-get install libftdi1-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
The initial tests include:
- MSRV with and without bindgen,
- successful operation with Nightly.
I don't test the bindings for being up to date as that may require pinning the `libftdi1` and distribution version.