### PR TITLE
[RFC] reexport libusb types from libusb1-sys

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,15 +11,18 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: MSRV
+        - name: MSRV (minimal)
           toolchain: 1.31.0
           features: ""
-        - name: MSRV-bindgen
+        - name: MSRV (libusb1-sys)
+          toolchain: 1.32.0
+          features: libusb1-sys
+        - name: MSRV (bindgen)
           toolchain: 1.34.0
           features: bindgen
         - name: Nightly
           toolchain: nightly
-          features: bindgen
+          features: libusb1-sys,bindgen
       fail-fast: false
 
     name: ${{ matrix.name }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,56 +7,35 @@ on:
     branches: [ master ]
 
 jobs:
-  msrv:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1.0.3
-      with:
-        toolchain: 1.31.0
-        profile: minimal
-        default: true
-    - name: Install libftdi1-dev
-      run: sudo apt-get install libftdi1-dev
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+  linux:
+    strategy:
+      matrix:
+        include:
+        - name: MSRV
+          toolchain: 1.31.0
+          features: ""
+        - name: MSRV-bindgen
+          toolchain: 1.34.0
+          features: bindgen
+        - name: Nightly
+          toolchain: nightly
+          features: bindgen
+      fail-fast: false
 
-  msrv-bindgen:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Install toolchain
       uses: actions-rs/toolchain@v1.0.3
       with:
-        toolchain: 1.34.0
+        toolchain: ${{ matrix.toolchain }}
         profile: minimal
         default: true
     - name: Install libftdi1-dev
       run: sudo apt-get install libftdi1-dev
-    - name: Build
-      run: cargo build --verbose --features=bindgen
-    - name: Run tests
-      run: cargo test --verbose --features=bindgen
-
-  nightly:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1.0.3
-      with:
-        toolchain: nightly
-        profile: minimal
-        default: true
-    - name: Install libftdi1-dev
-      run: sudo apt-get install libftdi1-dev
-    - name: Build and run tests (pregenerated)
-      run: cargo test --verbose
-    - name: Build and run tests (bindgen)
-      run: cargo test --verbose --features=bindgen
+    - run: cargo build --verbose --features=${{ matrix.features }}
+    - run: cargo test --verbose --features=${{ matrix.features }}
 
   windows-msvc:
     runs-on: windows-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ cfg-if = "0.1.10"
 libc = "0.2"
 
 [dependencies.libusb1-sys]
-version = "0.3.0"
+version = "0.3.7"
 optional = true
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ default = []
 cfg-if = "0.1.10"
 libc = "0.2"
 
+[dependencies.libusb1-sys]
+version = "0.3.0"
+optional = true
+
 [build-dependencies]
 cfg-if = "0.1.10"
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Regenerating bindings has an additional requirement that
   ```
 
 # MSRV
-The Minimum Supported Rust Version (MSRV) is stable `1.31` (Rust 2018) with pregenerated bindings,
-or `1.34` with the `bindgen` feature.
+The Minimum Supported Rust Version (MSRV) is stable `1.31` with default features,
+`1.32` with the `libusb1-sys` feature
+and `1.34` with the `bindgen` feature.
 
 # Features
+* `libusb1-sys`: depend on `libusb1-sys` and use real `libusb` types instead of placeholders.
+This makes it possible to interact directly with the underlying `libusb` structures.
 * `bindgen`: Generate bindings to `libftdi` at compile time.
 
 # Contributing

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
 
+use std::env;
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "bindgen")] {
         use bindgen;
 
-        use std::env;
         use std::path::PathBuf;
     }
 }
@@ -29,6 +30,15 @@ fn main() {
             err,
         );
         println!("cargo:rustc-link-lib=dylib=ftdi1");
+    }
+
+    if cfg!(feature = "libusb1-sys") {
+        match env::var("DEP_USB_1.0_STATIC") {
+            Ok(ref val) if val == "1" => {
+                panic!("libusb1-sys integration is not yet supported when it's linked statically");
+            }
+            _ => {}
+        }
     }
 
     cfg_if::cfg_if! {

--- a/build.rs
+++ b/build.rs
@@ -40,12 +40,12 @@ fn main() {
                     .rustfmt_bindings(true)
                     .whitelist_function("ftdi_.*")
                     .whitelist_type("ftdi_.*")
-                    .no_copy("libusb_.*")
                     .no_copy("ftdi_eeprom")
                     .no_copy("ftdi_device_list")
                     .no_copy("ftdi_context")
                     .no_copy("ftdi_transfer_control")
                     .blacklist_type("timeval")
+                    .blacklist_type("libusb_.*")
                     .blacklist_type("__.*")
                     .raw_line("pub type timeval = libc::timeval;")
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,42 @@
 // SPDX-License-Identifier: MIT
 
 //! libftdi1 is a library for working with FTDI chips like FT232BM, FT245BM,
-//! FT2232C, FT2232D, FT245R, FT232H, FT230X The documentation for it is
-//! available at http://www.intra2net.com/en/developer/libftdi/documentation/
+//! FT2232C, FT2232D, FT245R, FT232H, FT230X. The documentation for it is
+//! available [upstream].
 //!
-//! This wrapper was generated using rust-bindgen for libftdi 1.4.
+//! [upstream]: http://www.intra2net.com/en/developer/libftdi/documentation/
+//!
+//! This wrapper was generated using rust-bindgen.
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+
+use crate::libusb1_sys::*;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "bindgen")] {
         include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
     } else {
         include!("pregenerated.rs");
+    }
+}
+
+/// Internal placeholders for `libusb` types. Do not use externally.
+mod libusb1_sys {
+    #[repr(C)]
+    pub struct libusb_transfer {
+        _address: u8,
+    }
+    #[repr(C)]
+    pub struct libusb_context {
+        _address: u8,
+    }
+    #[repr(C)]
+    pub struct libusb_device_handle {
+        _address: u8,
+    }
+    #[repr(C)]
+    pub struct libusb_device {
+        _address: u8,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use crate::libusb1_sys::*;
+use crate::libusb1_sys::{libusb_device, libusb_context, libusb_device_handle, libusb_transfer};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "bindgen")] {
@@ -21,22 +21,28 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Internal placeholders for `libusb` types. Do not use externally.
-mod libusb1_sys {
-    #[repr(C)]
-    pub struct libusb_transfer {
-        _address: u8,
-    }
-    #[repr(C)]
-    pub struct libusb_context {
-        _address: u8,
-    }
-    #[repr(C)]
-    pub struct libusb_device_handle {
-        _address: u8,
-    }
-    #[repr(C)]
-    pub struct libusb_device {
-        _address: u8,
+cfg_if::cfg_if! {
+    if #[cfg(feature = "libusb1-sys")] {
+        pub use libusb1_sys;
+    } else {
+        /// Internal placeholders for `libusb` types. Do not use externally.
+        mod libusb1_sys {
+            #[repr(C)]
+            pub struct libusb_transfer {
+                _address: u8,
+            }
+            #[repr(C)]
+            pub struct libusb_context {
+                _address: u8,
+            }
+            #[repr(C)]
+            pub struct libusb_device_handle {
+                _address: u8,
+            }
+            #[repr(C)]
+            pub struct libusb_device {
+                _address: u8,
+            }
+        }
     }
 }

--- a/src/pregenerated.rs
+++ b/src/pregenerated.rs
@@ -926,26 +926,6 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug)]
-pub struct libusb_transfer {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct libusb_context {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct libusb_device_handle {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug)]
 pub struct ftdi_eeprom {
-    pub _address: u8,
-}
-#[repr(C)]
-#[derive(Debug)]
-pub struct libusb_device {
     pub _address: u8,
 }


### PR DESCRIPTION
This change would make it possible to enumerate and select devices in
ways `libftdi` does not directly support, as well as interoperate with
`rusb` and/or other USB-related crates.
On the other hand, it may be possible to get really confusing errors if
`libusb1-sys` and `libftdi` get linked against two different `libusb`
versions.

@roqvist / @cr1901 Any opinions? Merge / close / under a separate feature only?