### PR TITLE
ci: actually use specified toolchain versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
       with:
         toolchain: 1.31.0
         profile: minimal
+        default: true
     - name: Install libftdi1-dev
       run: sudo apt-get install libftdi1-dev
     - name: Build
@@ -32,6 +33,7 @@ jobs:
       with:
         toolchain: 1.34.0
         profile: minimal
+        default: true
     - name: Install libftdi1-dev
       run: sudo apt-get install libftdi1-dev
     - name: Build
@@ -48,6 +50,7 @@ jobs:
       with:
         toolchain: nightly
         profile: minimal
+        default: true
     - name: Install libftdi1-dev
       run: sudo apt-get install libftdi1-dev
     - name: Build and run tests (pregenerated)
@@ -67,6 +70,7 @@ jobs:
         toolchain: 1.34.0
         target: x86_64-pc-windows-msvc
         profile: minimal
+        default: true
     - name: Restore / setup vcpkg and libftdi1
       uses: lukka/run-vcpkg@master
       with:


### PR DESCRIPTION
They need to be actually set as default.