### PR TITLE
[RFC] `vendored` feature

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,29 +14,41 @@ jobs:
         - name: MSRV (minimal)
           toolchain: 1.31.0
           features: ""
+        - name: MSRV (vendored)
+          toolchain: 1.31.0
+          features: vendored
+          native_deps: libusb-1.0-0-dev
         - name: MSRV (libusb1-sys)
           toolchain: 1.32.0
           features: libusb1-sys
+        - name: vendored,libusb1-sys
+          toolchain: 1.32.0
+          features: libusb1-sys,vendored
+          native_deps: libusb-1.0-0-dev
         - name: MSRV (bindgen)
           toolchain: 1.34.0
           features: bindgen
         - name: Nightly
           toolchain: nightly
-          features: libusb1-sys,bindgen
+          features: libusb1-sys,vendored,bindgen
+          native_deps: libusb-1.0-0-dev
       fail-fast: false
 
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Install toolchain
       uses: actions-rs/toolchain@v1.0.3
       with:
         toolchain: ${{ matrix.toolchain }}
         profile: minimal
         default: true
-    - name: Install libftdi1-dev
-      run: sudo apt-get install libftdi1-dev
+    - if: ${{ matrix.native_deps || 'libftdi1-dev' }}
+      name: Install native packages (${{ matrix.native_deps || 'libftdi1-dev' }})
+      run: sudo apt-get install ${{ matrix.native_deps || 'libftdi1-dev' }}
     - run: cargo build --verbose --features=${{ matrix.features }}
     - run: cargo test --verbose --features=${{ matrix.features }}
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libftdi1-source-lgpl/libftdi"]
+	path = libftdi1-source-lgpl/libftdi
+	url = git://developer.intra2net.com/libftdi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,12 @@ build = "build.rs"
 
 [features]
 default = []
+vendored = ["libftdi1-source-lgpl", "cc"]
 
 [dependencies]
 cfg-if = "0.1.10"
 libc = "0.2"
+libftdi1-source-lgpl = {version = "=1.4.0", path = "libftdi1-source-lgpl", optional = true}
 
 [dependencies.libusb1-sys]
 version = "0.3.7"
@@ -33,6 +35,7 @@ optional = true
 
 [build-dependencies]
 cfg-if = "0.1.10"
+cc = {version = "1.0.52", optional = true}
 
 [target.'cfg(not(all(windows, target_env="msvc")))'.build-dependencies]
 pkg-config = "0.3.7"
@@ -43,3 +46,6 @@ vcpkg = "0.2"
 [build-dependencies.bindgen]
 version = "0.53.2"
 optional = true
+
+[workspace]
+members = [".", "libftdi1-source-lgpl"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 # Prerequisites
 This crate requires `libftdi1` version 1.4 (August 2017) or later to be available as a system library
-that can be found with `pkg-config` (everywhere except windows/MSVC) or `vcpkg` (windows/MSVC).
+that can be found with `pkg-config` (everywhere except windows/MSVC) or `vcpkg` (windows/MSVC)
+unless you activate the `vendored` feature.
 
 By default the crate uses pregenerated bindings which should be fine in most cases.
 In special cases the bindings can be regenerated using the `bindgen` feature.
@@ -30,6 +31,8 @@ and `1.34` with the `bindgen` feature.
 # Features
 * `libusb1-sys`: depend on `libusb1-sys` and use real `libusb` types instead of placeholders.
 This makes it possible to interact directly with the underlying `libusb` structures.
+* `vendored`: build a custom copy of `libftdi` instead of using the system one.
+Note that this includes LGPL code in your build.
 * `bindgen`: Generate bindings to `libftdi` at compile time.
 
 # Contributing

--- a/libftdi1-source-lgpl/Cargo.toml
+++ b/libftdi1-source-lgpl/Cargo.toml
@@ -1,0 +1,31 @@
+# See https://doc.rust-lang.org/cargo/reference/manifest.html for full list
+[package]
+name = "libftdi1-source-lgpl"
+version = "1.4.0"
+authors = ["Denis Lisov <dennis.lissov@gmail.com>", "libFTDI authors"]
+edition = "2018"
+
+description = "libFTDI source code bundle for libftdi1-sys (internal use only)"
+#documentation = ""
+readme = "README.md"
+#homepage = ""
+repository = "https://github.com/tanriol/libftdi1-sys"
+
+license = "LGPL-2.1"
+links = "ftdi1_source"
+
+include = [
+    "Cargo.toml",
+    "build.rs",
+    "lib.rs",
+    "libftdi/src/*",
+    "README.md",
+]
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+
+[badges]
+maintenance = { status = "passively-maintained" }

--- a/libftdi1-source-lgpl/README.md
+++ b/libftdi1-source-lgpl/README.md
@@ -1,0 +1,17 @@
+### Internal use only!
+
+This crate provides the LGPL source of `libftdi` for `libftdi1-sys[vendored]`.
+If your dependency tree includes this crate, your final binary likely includes LGPL-licensed code.
+If you're not sure whether that's acceptable for your use case, please consult your lawyer.
+
+The only reason this is a separate crate is to provide correct licensing metadata
+because `libftdi1-sys` is permissively licensed, while the vendored source is LGPL.
+You should not depend on it directly.
+
+Version `X.Y.Z` of this crate is interpreted as "`libftdi X.Y`, crate revision Z".
+As a result, it may not follow SemVer if `libftdi` ever breaks it.
+Thus `libftdi1-sys` uses strict version dependencies like `=1.4.0`.
+
+Note that the repository refers to the `libftdi` repository as a submodule,
+and that repository contains code under multiple licenses including GPL.
+The crate package, however, takes care to include only LGPL components.

--- a/libftdi1-source-lgpl/build.rs
+++ b/libftdi1-source-lgpl/build.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LGPL-2.1
+
+use std::{fs, path::PathBuf};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let version_string = format!(
+        "{}.{}",
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        env!("CARGO_PKG_VERSION_MINOR"),
+    );
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+    let target_dir = out_dir.join("source");
+    let _ = fs::remove_dir_all(&target_dir);
+    fs::create_dir(&target_dir)?;
+    for entry in fs::read_dir("libftdi/src")? {
+        let entry = entry?;
+        if entry.file_name() != "ftdi_version_i.h.in" {
+            fs::copy(entry.path(), target_dir.join(entry.file_name()))?;
+        } else {
+            let text = fs::read_to_string(entry.path())?;
+            let rendered = text
+                .replace("@MAJOR_VERSION@", env!("CARGO_PKG_VERSION_MAJOR"))
+                .replace("@MINOR_VERSION@", env!("CARGO_PKG_VERSION_MINOR"))
+                .replace("@VERSION_STRING@", &version_string)
+                .replace("@SNAPSHOT_VERSION@", "");
+            fs::write(target_dir.join("ftdi_version_i.h"), rendered)?;
+        }
+    }
+    println!("cargo:source-dir={}", target_dir.to_str().unwrap());
+
+    Ok(())
+}

--- a/libftdi1-source-lgpl/lib.rs
+++ b/libftdi1-source-lgpl/lib.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: LGPL-2.1
+
+//! This crate provides the LGPL source of `libftdi` for `libftdi1-sys[vendored]`.
+//! If your dependency tree includes this crate, your final binary likely includes LGPL-licensed code.
+//! If you're not sure whether that's acceptable for your use case, please consult your lawyer.
+
+/// Reports the version of `libftdi` this package provides.
+pub fn libftdi_version() -> String {
+    return format!(
+        "{}.{}",
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        env!("CARGO_PKG_VERSION_MINOR"),
+    );
+}


### PR DESCRIPTION
A new approach to vendoring `libftdi` with the crate(s). Uses one additional crate, no symlinks, seems to link correctly in all cases. Based on #11.