### PR TITLE
Update libusb-sys crate to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ libc = "0.2"
 libftdi1-source-lgpl = {version = "=1.5.0", path = "libftdi1-source-lgpl", optional = true}
 
 [dependencies.libusb1-sys]
-version = "0.3.7"
+version = "0.5.0"
 optional = true
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ libc = "0.2"
 libftdi1-source-lgpl = {version = "=1.5.0", path = "libftdi1-source-lgpl", optional = true}
 
 [dependencies.libusb1-sys]
-version = "0.5.0"
+version = ">=0.3.7, <0.6"
 optional = true
 
 [build-dependencies]


### PR DESCRIPTION
Thanks for creating this crate!

Would it be possible to update the `libusb1-sys` dependency to the newest version? This would allow it to work together with `rusb`, which also uses version `0.5.0`.